### PR TITLE
add fix for blocked pockets

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,6 @@
+LSMO version with fixes on top of zeo++ v0.3.0
+
+
 Zeo++, high-throughput analysis of crystalline porous materials
 By Maciej Haranczyk, Chris H Rycroft, Richard L Martin, Thomas F Willems
 

--- a/README
+++ b/README
@@ -1,6 +1,3 @@
-LSMO version with fixes on top of zeo++ v0.3.0
-
-
 Zeo++, high-throughput analysis of crystalline porous materials
 By Maciej Haranczyk, Chris H Rycroft, Richard L Martin, Thomas F Willems
 


### PR DESCRIPTION
If the pockets in a system were not clearly separated from the channels,
zeo++ could go into into infinite loops.

Note: Without this fix, enabling blocked pockets here:
https://github.com/ltalirz/aiida-zeopp/blob/1c4c5dbec8b6383f902d01ba8aa7efc19bfc2af0/examples/example_01.py#L29-L36
makes zeo++ run forever (instead of 20s)